### PR TITLE
Make serverName configuration setting optional, and derive if it is not provided.

### DIFF
--- a/DotNetCasClient/CasAuthentication.cs
+++ b/DotNetCasClient/CasAuthentication.cs
@@ -289,7 +289,8 @@ namespace DotNetCasClient
                         bool haveServerName = !String.IsNullOrEmpty(serverName);
                         if (!haveServerName)
                         {
-                            LogAndThrowConfigurationException(CasClientConfiguration.SERVER_NAME + " cannot be null or empty.");
+                            //If serverName configuration setting is not provided, derive current URL of application
+                            serverName = FullApplicationPath();
                         }
 
                         if (String.IsNullOrEmpty(casServerLoginUrl))
@@ -321,6 +322,16 @@ namespace DotNetCasClient
                 if (ProxyTicketManager != null) ProxyTicketManager.Initialize();
                 if (TicketValidator != null) TicketValidator.Initialize();
             }
+        }
+
+        /// <summary>
+        /// Used to obtain the current URL based on HttpContext if serverName configuration setting is not specified
+        /// </summary>
+        /// <returns></returns>
+        public static string FullApplicationPath()
+        {
+            return HttpContext.Current.Request.Url.AbsoluteUri.Replace(HttpContext.Current.Request.Url.AbsolutePath,
+            string.Empty) + HttpContext.Current.Request.ApplicationPath;
         }
 
         /// <summary>

--- a/ExampleWebSite/web.config.sample
+++ b/ExampleWebSite/web.config.sample
@@ -43,16 +43,6 @@
     
         - casServerLoginUrl
                 URL of CAS login form.
-        - serverName
-                Host name of the server hosting this application.  This is used to generate URLs 
-                that will be sent to the CAS server for redirection.  The CAS server must be able
-                to resolve this host name.  If your web application is behind a load balancer, SSL
-                offloader, or any other type of device that accepts incoming requests on behalf of
-                the web application, you will generally need to supply the public facing host name
-                unless your CAS server is in the same private network as the application server.  
-                The protocol prefix is optional (http:// or https://).  If you are using a non-
-                standard port number, be sure to include it (i.e., server.school.edu:8443 or 
-                https://cas.example.com:8443).  Do not include the trailing backslash.
         - casServerUrlPrefix
                 URL to root of CAS server application.
         - ticketValidatorName
@@ -60,6 +50,17 @@
                 Name of ticket validator that validates CAS tickets using a particular protocol.
 
         Optional Attributes:
+         - serverName
+                Host name of the server hosting this application.  This is used to generate URLs 
+                that will be sent to the CAS server for redirection. If serverName is not provided, 
+                the URL will be derived based on current HttpContext. The CAS server must be able
+                to resolve this host name.  If your web application is behind a load balancer, SSL
+                offloader, or any other type of device that accepts incoming requests on behalf of
+                the web application, you will generally need to supply the public facing host name
+                unless your CAS server is in the same private network as the application server.  
+                The protocol prefix is optional (http:// or https://).  If you are using a non-
+                standard port number, be sure to include it (i.e., server.school.edu:8443 or 
+                https://cas.example.com:8443).  Do not include the trailing backslash.
         - gateway (default false)
                 Enable CAS gateway feature, see http://www.jasig.org/cas/protocol section 2.1.1.
         - renew (default true)


### PR DESCRIPTION
Updated to make serverName configuration setting optional. If serverName is left blank or is not provided, the application URL is derived from HttpContext.

This is a requirement for our deployment environment, as developers are only allowed access to development deployment locations on web servers and do not have the ability to change web.config settings when an application that is migrated from development to staging or production. As applications are moved up the deployment stack, the URL for the application changes, thus we needed the ability to automatically derive the serverName attribute to effectively use the CAS client.
