### PR TITLE
NETC-45 Exclude service parameter from encoded service URL.

### DIFF
--- a/DotNetCasClient/Utils/UrlUtil.cs
+++ b/DotNetCasClient/Utils/UrlUtil.cs
@@ -99,6 +99,7 @@ namespace DotNetCasClient.Utils
             EnhancedUriBuilder ub = new EnhancedUriBuilder(buffer.ToString());
             ub.Path = request.Url.AbsolutePath;
             ub.QueryItems.Add(request.QueryString);
+            ub.QueryItems.Remove(CasAuthentication.TicketValidator.ServiceParameterName);
             ub.QueryItems.Remove(CasAuthentication.TicketValidator.ArtifactParameterName);
 
             if (gateway)


### PR DESCRIPTION
Sample validation URL before prior to this patch:

DotNetCasClient.Protocol Verbose: 3237 : Constructed validation URL https://eiger.middleware.vt.edu/cas/samlValidate?TARGET=https%3a%2f%2feiger.middleware.vt.edu%3a4443%2fNetcExample%2fRestricted%2fAuthenticatedUsersOnly%2fdefault.aspx%3fTARGET%3dhttps%3a%2f%2feiger.middleware.vt.edu%3a4443%2fNetcExample%2fRestricted%2fAuthenticatedUsersOnly%2fdefault.aspx&SAMLart=AAFSsPYAkNKN6Mb0Q6Li8D8gawrtLJqGNltOTEgvpU2pxxKt/cHT4QOa&renew=true

After patch:

DotNetCasClient.Protocol Verbose: 3237 : Constructed validation URL https://eiger.middleware.vt.edu/cas/samlValidate?TARGET=https%3a%2f%2feiger.middleware.vt.edu%3a4443%2fNetcExample%2fRestricted%2fAuthenticatedUsersOnly%2fdefault.aspx&SAMLart=AAFSsPYAkNKN6Mb0Q6Li8D8gawrtLBoadIuVEL4nh7vKiZUOGt/nIIrY&renew=true
