### PR TITLE
NETC-48: This issue may be related to a missing volatile keyword

### DIFF
--- a/DotNetCasClient/CasAuthentication.cs
+++ b/DotNetCasClient/CasAuthentication.cs
@@ -60,7 +60,7 @@ namespace DotNetCasClient
 
         // Thread-safe initialization
         private static readonly object LockObject;
-        private static bool initialized;
+        private static volatile bool initialized;
 
         // System.Web/Authentication and System.Web/Authentication/Forms static classes
         internal static AuthenticationSection AuthenticationConfig;


### PR DESCRIPTION
This issue may be related to a missing volatile keyword in the static bool "initialized". CasAuthentication.Initialize() appears to be performing a double-check lock technique with this variable so I believe the volatile keyword would need to be present. See the "Multithreaded Singleton" section on this MSDN link:
http://msdn.microsoft.com/en-us/library/ff650316.aspx
