### PR TITLE
NETC-60 URL encode ticket parameter value.

### DIFF
--- a/DotNetCasClient/Utils/UrlUtil.cs
+++ b/DotNetCasClient/Utils/UrlUtil.cs
@@ -139,7 +139,7 @@ namespace DotNetCasClient.Utils
 
             EnhancedUriBuilder ub = new EnhancedUriBuilder(EnhancedUriBuilder.Combine(CasAuthentication.CasServerUrlPrefix, CasAuthentication.TicketValidator.UrlSuffix));
             ub.QueryItems.Add(CasAuthentication.TicketValidator.ServiceParameterName, HttpUtility.UrlEncode(ConstructServiceUrl(gateway)));
-            ub.QueryItems.Add(CasAuthentication.TicketValidator.ArtifactParameterName, serviceTicket);
+            ub.QueryItems.Add(CasAuthentication.TicketValidator.ArtifactParameterName, HttpUtility.UrlEncode(serviceTicket));
 
             if (renew)
             {


### PR DESCRIPTION
Verified change in our infrastructure against both CAS 2.0 and SAML 1.1 protocols.
