### PR TITLE
Limit substrings returned by Split in CreateItemsFromQuery()

### DIFF
--- a/DotNetCasClient/Utils/EnhancedUriBuilder.cs
+++ b/DotNetCasClient/Utils/EnhancedUriBuilder.cs
@@ -277,7 +277,7 @@ namespace DotNetCasClient.Utils
                 {
                     if (item.Length > 0)
                     {
-                        string[] namevalue = item.Split('=');
+                        string[] namevalue = item.Split(new char[] { '=' }, 2);
                         _QueryItems.Add(namevalue[0], namevalue.Length > 1 ? namevalue[1] : String.Empty);
                     }
                 }


### PR DESCRIPTION
Problem: item.Split('=')
Explanation: `Split truncates trailing "=" in value portion: ("SAMLRequest=dx9Pwbw==").Split('=') == { "SAMLRequest", "dx9Pwbw" }`

Resolution: item.Split(new char[] { '=' }, 2)
Explanation: Limits substrings returned by split: `("SAMLRequest=dx9Pwbw==").Split(new char[] { '=' }, 2) == { "SAMLRequest", "dx9Pwbw==" }`
