### PR TITLE
Re-encode query items in this relayState previously decoded by EnhancedUriBuilder.CreateItemsFromQuery() method

### DIFF
--- a/DotNetCasClient/Utils/UrlUtil.cs
+++ b/DotNetCasClient/Utils/UrlUtil.cs
@@ -357,6 +357,11 @@ namespace DotNetCasClient.Utils
             ub.Scheme = uriServerName.Scheme;
             ub.Host = uriServerName.Host;
             ub.Port = uriServerName.Port;
+            
+            foreach (string k in ub.QueryItems.AllKeys)
+            {
+                ub.QueryItems[k] = HttpUtility.UrlEncode(ub.QueryItems[k]);
+            }
 
             return ub.Uri.AbsoluteUri;
         }


### PR DESCRIPTION
SAML requests are passed around as a query string parameter, GZIP deflated, Base64 encoded and must remain URL encoded until reaching its final destination (i.e. IdP). However they were found to be URL decoded on `CasAuthentication.RedirectFromLoginCallback()` by `EnhancedUriBuilder.CreateItemsFromQuery()` resulting in "corruption" of data prior to inflating, as in: `Failed to decode the SAML message using deflate` ([ComponentSpace](http://www.componentspace.com/SAMLv20.aspx))
