### PR TITLE
Fixes for URL encoded query string data in service URLs

### DIFF
--- a/DotNetCasClient/Utils/EnhancedUriBuilder.cs
+++ b/DotNetCasClient/Utils/EnhancedUriBuilder.cs
@@ -270,14 +270,19 @@ namespace DotNetCasClient.Utils
 
             if (base.Query.Length > 0)
             {
-                string query = HttpUtility.UrlDecode(base.Query.Substring(1));
+                // The Query component of the URI always begins with the ? separator, so get the entire string
+                // after that, then split the string on the & separator, which is how each query item is delimited
+                string query = base.Query.Substring(1);
                 string[] items = query.Split('&');
 
                 foreach (string item in items)
                 {
                     if (item.Length > 0)
                     {
-                        string[] namevalue = item.Split('=');
+                        // Split the query item into a name/value pair, delimited by the first occurrence of =. Any
+                        // subsequent occurrences will be ignored despite being illegal as a non-URL encoded character
+                        string[] namevalue = item.Split(new char[] {'='}, 2);
+                        // Add the name/value pair to the query item collection
                         _QueryItems.Add(namevalue[0], namevalue.Length > 1 ? namevalue[1] : String.Empty);
                     }
                 }
@@ -291,8 +296,8 @@ namespace DotNetCasClient.Utils
         {
             if (_QueryItems != null)
             {
-                // First check if queryItems has been cleared (using 
-                // QueryItems.Clear()), because this doesn't 
+                // First check if queryItems has been cleared (using
+                // QueryItems.Clear()), because this doesn't
                 // update dirty flag!!!
                 if (_QueryItems.Count == 0)
                 {

--- a/DotNetCasClient/Utils/UrlUtil.cs
+++ b/DotNetCasClient/Utils/UrlUtil.cs
@@ -98,7 +98,14 @@ namespace DotNetCasClient.Utils
 
             EnhancedUriBuilder ub = new EnhancedUriBuilder(buffer.ToString());
             ub.Path = request.Url.AbsolutePath;
-            ub.QueryItems.Add(request.QueryString);
+
+            // Iterate through each of the name/value pairs in the query component of the service URL
+            foreach(string name in request.QueryString.AllKeys)
+            {
+                // URL encode each name/value pair and then add it to the query items collection
+                ub.QueryItems.Add(HttpUtility.UrlEncode(name), HttpUtility.UrlEncode(request.QueryString[name]));
+            }
+
             ub.QueryItems.Remove(CasAuthentication.TicketValidator.ServiceParameterName);
             ub.QueryItems.Remove(CasAuthentication.TicketValidator.ArtifactParameterName);
 


### PR DESCRIPTION
Fixes #18 and #19.

This PR is an expansion of **scottt732**'s `url-encoding-bugfix` branch that additionally fixes issues with URL encoded data in a service URL when the request has to first be redirected to the CAS server (in which case it goes through more URL encodes/decodes).

**Easy Test Case**

1. With current `master` branch and a clean browser state (i.e. no existing CAS session) navigate to your application's URL with the query string of `?data=%2B`.
2. After successful CAS login, the `data` query item value will be a space (because most browsers interpret the `+` as a space when decoded).
3. While still having the active CAS session, navigate to the same URL as in step 1. The `data` query item value will now be the correct value of `+`. 
4. End your CAS session (e.g. closing browser/clearing cache)
5. Rebuild the application with this branch.
6. Navigate to the same URL as in step 1.
7. Login with CAS.
8. The `data` query item value will correctly be `+`. All subsequent requests to the same URL will still yield a `data` value of `+`.

**Other Test Cases**

Per issue #18, the OP had example initial `data` values of (service URL value => final value):

- `7J%2fMlsKOh99bxaaUpZSeJRD0avGuP%2brv%2fRo48w4%2brHTk%2bSQ628pOYLZ0zyUzj2M7TwhZdt6mrtyb7419rMmsSQ%3d%3d` => `7J/MlsKOh99bxaaUpZSeJRD0avGuP+rv/Ro48w4+rHTk+SQ628pOYLZ0zyUzj2M7TwhZdt6mrtyb7419rMmsSQ==`
- `XfFhVx%2fy7vGiBQjq5MC%2fbfaGM6KZnDBSOISIwmmj7BM%3d` => `XfFhVx/y7vGiBQjq5MC/bfaGM6KZnDBSOISIwmmj7BM=`

These should be interchangeable into the easy test case scenario to show that, before the fixes in this branch, the initial request that results in CAS authentication fails to preserve the query string data properly. But this PR should _always_ preserve that query string, regardless of the state of CAS authentication.