### PR TITLE
ITicketValidator should be public

### DIFF
--- a/DotNetCasClient/Validation/TicketValidator/ITicketValidator.cs
+++ b/DotNetCasClient/Validation/TicketValidator/ITicketValidator.cs
@@ -36,7 +36,7 @@ namespace DotNetCasClient.Validation.TicketValidator
     /// <author>Scott Battaglia</author>
     /// <author>William G. Thompson, Jr. (.Net)</author>
     /// <author>Scott Holodak (.Net)</author>
-    interface ITicketValidator
+    public interface ITicketValidator
     {
         #region Properties
         /// <summary>


### PR DESCRIPTION
ITicketValidator should be public to allow customization via "ticketValidatorName" in config