### PR TITLE
Fix Issue 77

### DIFF
--- a/DotNetCasClient/DotNetCasClient.csproj
+++ b/DotNetCasClient/DotNetCasClient.csproj
@@ -29,25 +29,18 @@
     <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='net35' OR '$(TargetFramework)'=='net20'">
+  <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)'=='net35' OR '$(TargetFramework)'=='net20'">
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)'=='net45' OR '$(TargetFramework)'=='net40'">
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.Caching" />
-    <Reference Include="System.Web" />
     <Reference Include="System.Web.ApplicationServices" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
 </Project>

--- a/DotNetCasClient/DotNetCasClient.nuspec
+++ b/DotNetCasClient/DotNetCasClient.nuspec
@@ -18,12 +18,9 @@
         <frameworkAssemblies>
             <frameworkAssembly assemblyName="System" />
             <frameworkAssembly assemblyName="System.Configuration" />
-            <frameworkAssembly assemblyName="System.Data" />
-            <frameworkAssembly assemblyName="System.Drawing" />
             <frameworkAssembly assemblyName="System.Runtime.Caching" targetFramework="net40, net45" />
             <frameworkAssembly assemblyName="System.Web" />
             <frameworkAssembly assemblyName="System.Web.ApplicationServices" targetFramework="net40, net45" />
-            <frameworkAssembly assemblyName="System.Windows.Forms" />
             <frameworkAssembly assemblyName="System.Xml" />
         </frameworkAssemblies>
     </metadata>


### PR DESCRIPTION
These changes to the `.csproj` file clean up unused assembly references:
- `System.Data`
- `System.Drawing`
- `System.Windows.Forms`

They also consolidate the following common references across all frameworks into a non-conditional item group:
- `System`
- `System.Configuration`
- `System.Web`
- `System.Xml`

Finally, the NuGet spec file is updated to reflect these changes. Note that the project still has implicit references to unused assemblies that are caused by the reference to the .NET SDK.

Fixes #77.