### PR TITLE
SingleSignOut causes A potentially dangerous Request.Form exception #81

### DIFF
--- a/DotNetCasClient/CasAuthentication.cs
+++ b/DotNetCasClient/CasAuthentication.cs
@@ -737,13 +737,22 @@ namespace DotNetCasClient
 
             protoLogger.Debug("Examining request for single sign-out signature");
 
+#if NET45
             if (request.HttpMethod == "POST" && request.Unvalidated.Form["logoutRequest"] != null)
+#else
+            if (request.HttpMethod == "POST" && request.Form["logoutRequest"] != null)
+#endif
+
             {
                 protoLogger.Debug("Attempting to get CAS service ticket from request");
                 // TODO: Should we be checking to make sure that this special POST is coming from a trusted source?
                 //       It would be tricky to do this by IP address because there might be a white list or something.
-                
+#if NET45
                 string casTicket = ExtractSingleSignOutTicketFromSamlResponse(request.Unvalidated.Form["logoutRequest"]);
+#else
+                string casTicket = ExtractSingleSignOutTicketFromSamlResponse(request.Params["logoutRequest"]);
+#endif
+
                 if (!String.IsNullOrEmpty(casTicket))
                 {
                     protoLogger.Info("Processing single sign-out request for " + casTicket);


### PR DESCRIPTION
#80 

After logout CAS sends post request message=<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="LR-177-X8BLQyvy76SFszPwCMYwpFeF" Version="2.0" IssueInstant="2018-04-12T15:07:21Z"><saml:NameID xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">@NOT_USED@</saml:NameID><samlp:SessionIndex>ST-2171-iZF3BlhCp9VdarvPV-tJ1GEebO0-kaspi-portsso1</samlp:SessionIndex></samlp:LogoutRequest>,asynchronous=false,contentType=application/x-www-form-urlencoded

And dotnet-cas-client tryes get logoutRequest from HttpContext.Current.Request.Form

```
internal static void ProcessSingleSignOutRequest()
        {
            HttpContext context = HttpContext.Current;
            HttpRequest request = context.Request;
            HttpResponse response = context.Response;
            protoLogger.Debug("Examining request for single sign-out signature");

            if (request.HttpMethod == "POST" && request.Form["logoutRequest"] != null)
            {
```
getting value is causing exception - context.Request.Form["logoutRequest"]	'context.Request.Form["logoutRequest"]' threw an exception of type 'System.Web.HttpRequestValidationException'	string {System.Web.HttpRequestValidationException}
